### PR TITLE
Feature: Add dry-run option

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,5 +24,6 @@ jobs:
           SYSTEM: aws
           VERSION: v0.1.6+${{ github.sha }}
           MODULES_PATH: ./test/
+          DRY_RUN: 'false'
         run:
           bash ./push_repository.sh

--- a/README.md
+++ b/README.md
@@ -4,17 +4,18 @@ Github Action for publishing your modules on your own registry.
 ## Customizing
 ### Inputs
 
-| Name                      | Type   | Description                                                                                                                  |
-|---------------------------|--------|------------------------------------------------------------------------------------------------------------------------------|
-| `api-key`                 | String | API Key used to authenticate to the registry.                                                                                |
-| `hostname`                | String | URL of your registry.                                                                                                        |
-| `namespace`               | String | Is the name of a namespace, unique on a particular hostname, that can contain one or more modules that are somehow related.  |
-| `module-name`             | String | Name of the module.                                                                                                          |
-| `system`                  | String | Name of a remote system that the module is primarily written to target.                                                       |
-| `version`                 | String | Version of the module.                                                                                                       |
-| `modules-path`            | String | ath where the code is.                                                                                                       |
-| `lower-terraform-version` | Number | Lower allowed terraform version.                                                                                                      |
-| `higher-terraform-version`| Number | Higher allowed terraform version.                                                                                                      |
+| Name                       | Type   | Description                                                                                                                 |
+| -------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `api-key`                  | String | API Key used to authenticate to the registry.                                                                               |
+| `hostname`                 | String | URL of your registry.                                                                                                       |
+| `namespace`                | String | Is the name of a namespace, unique on a particular hostname, that can contain one or more modules that are somehow related. |
+| `module-name`              | String | Name of the module.                                                                                                         |
+| `system`                   | String | Name of a remote system that the module is primarily written to target.                                                     |
+| `version`                  | String | Version of the module.                                                                                                      |
+| `path-to-zip`             | String | Path where the code is.                                                                                                      |
+| `lower-terraform-version`  | Number | Lower allowed terraform version.                                                                                            |
+| `higher-terraform-version` | Number | Higher allowed terraform version.                                                                                           |
+| `dry-run`                  | String | Whether or not to perform a dry run (without pushing the module to the registry).                                           |
 
 ## Example usage
 ```yaml
@@ -26,7 +27,8 @@ with:
   module-name: ecr
   system: aws
   version: v1.0.0
-  modules-path: modules/
+  path-to-zip: modules/
+  dry-run: 'false'
 ```
 The example above will upload your code to `https://registry.acme.com/example/ecr/aws/1.0.0`
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Github Action for publishing your modules on your own registry.
 | `module-name`              | String | Name of the module.                                                                                                         |
 | `system`                   | String | Name of a remote system that the module is primarily written to target.                                                     |
 | `version`                  | String | Version of the module.                                                                                                      |
-| `path-to-zip`             | String | Path where the code is.                                                                                                      |
+| `path-to-zip`              | String | Path where the code is.                                                                                                     |
 | `lower-terraform-version`  | Number | Lower allowed terraform version.                                                                                            |
 | `higher-terraform-version` | Number | Higher allowed terraform version.                                                                                           |
 | `dry-run`                  | String | Whether or not to perform a dry run (without pushing the module to the registry).                                           |

--- a/action.yaml
+++ b/action.yaml
@@ -38,6 +38,10 @@ inputs:
     description: 'List of paths and files to exclude in the package.'
     required: false
     default: ''
+  dry-run:
+    description: 'Whether or not to perform a dry run (without pushing the module to the registry).'
+    required: false
+    default: 'false'
 
 runs:
   using: 'docker'
@@ -53,6 +57,7 @@ runs:
     LOWER_TERRAFORM_VERSION: ${{ inputs.lower-terraform-version }}
     HIGHER_TERRAFORM_VERSION: ${{ inputs.higher-terraform-version }}
     EXCLUDE: ${{ inputs.paths-files-to-exclude }}
+    DRY_RUN: ${{ inputs.dry-run }}
     
 
 

--- a/push_repository.sh
+++ b/push_repository.sh
@@ -47,5 +47,8 @@ fi
 
 zip -r modules.zip $MODULES_PATH -x .git\* push_repository.sh terraform_required_versions.py requirements.txt $EXCLUDE
 echo ''"$HOSTNAME"'/'"$NAMESPACE"'/'"$NAME"'/'"$SYSTEM"'/'"$VERSION"'/upload'
-wget --no-check-certificate -v --method POST --timeout=0 --header "$AUTH" --header 'Content-Type: application/zip' \
-        --body-file="$DATA" ''"$HOSTNAME"'/'"$NAMESPACE"'/'"$NAME"'/'"$SYSTEM"'/'"$VERSION"'/upload'
+
+if [ "$DRY_RUN" = "false" ]; then
+        wget --no-check-certificate -v --method POST --timeout=0 --header "$AUTH" --header 'Content-Type: application/zip' \
+             --body-file="$DATA" ''"$HOSTNAME"'/'"$NAMESPACE"'/'"$NAME"'/'"$SYSTEM"'/'"$VERSION"'/upload'
+fi


### PR DESCRIPTION
# Modules affected

* `.github/workflows/test.yaml`
* `README.md`
* `action.yaml`
* `push_repository.sh`

# 🚨 Impact
From now own, you can select whether you want to actually push the module to the registry or not. This will be useful while running pipelines to check the code before we create a new release. 

# What's Changed

**Full Changelog**: https://github.com/craftech-io/publish-terraform-module-action/compare/v1.2.0...feature/dry-run